### PR TITLE
Fix deadlock in ProcessPoolExecutor by disabling worker recycling

### DIFF
--- a/src/negmas/tournaments/tournaments.py
+++ b/src/negmas/tournaments/tournaments.py
@@ -63,7 +63,7 @@ __all__ = [
     "tournament",
 ]
 
-MAX_TASKS_PER_CHILD = 10
+MAX_TASKS_PER_CHILD = None
 TIMEOUT_EXTRA = 1.05
 
 


### PR DESCRIPTION
This PR sets `MAX_TASK_PER_PROCCESS` to `None`. This resolves a critical issue where the `ProcessPoolExecutor` would hang indefinitely during the **running phase** when trying to recycle worker processes.

### Key Changes
* **Disabled Worker Recycling:** Worker processes now persist for the entire duration of the pool's lifecycle.
* **Stability:** Eliminates the silent deadlocks caused by process termination and re-initialization.

### Impact
* **Reliability:** Fixes execution stalls encountered during parallel tasks.
* **Trade-off:** Prioritizes stable execution over memory reclamation, ensuring long-running tasks complete without manual intervention.